### PR TITLE
Minimal cmake version: 3.5

### DIFF
--- a/qAutoSeg/CMakeLists.txt
+++ b/qAutoSeg/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 3.0 )
+cmake_minimum_required( VERSION 3.5 )
 
 # CloudCompare Masonry Manual Segmentation plugin
 option( PLUGIN_STANDARD_MASONRY_QAUTO_SEG "Check to install QAutoSeg plugin" OFF )
@@ -6,7 +6,7 @@ option( PLUGIN_STANDARD_MASONRY_QAUTO_SEG "Check to install QAutoSeg plugin" OFF
 if ( PLUGIN_STANDARD_MASONRY_QAUTO_SEG )
 
     project( QAUTO_SEG_PLUGIN )
-    
+
     AddPlugin( NAME ${PROJECT_NAME} )
 
 	target_sources( ${PROJECT_NAME}
@@ -31,7 +31,7 @@ if ( PLUGIN_STANDARD_MASONRY_QAUTO_SEG )
 	# Find OpenCV
 	#set( OpenCV_DIR "C:/opencv/build" ) #DGM: can't do that as it will obviously conflict with most of the users settings ;)
 	find_package( OpenCV REQUIRED )
-	
+
 	if (WIN32)
 		# We need to copy the OpenCV "World" DLL file next to CloudCompare.exe
 		set( OpenCV_WORLD_DLL "" CACHE FILEPATH "Opencv 'World' DLL file path" )
@@ -48,7 +48,7 @@ if ( PLUGIN_STANDARD_MASONRY_QAUTO_SEG )
 		# [C/C++]>[Preprocessor]>[Preprocessor Definitions]
 		add_definitions( ${PCL_DEFINITIONS} )
 
-		# For Use Not PreCompiled Features 
+		# For Use Not PreCompiled Features
 		#add_definitions( -DPCL_NO_PRECOMPILE )
 
 		# [Linker]>[General]>[Additional Library Directories]
@@ -67,7 +67,7 @@ if ( PLUGIN_STANDARD_MASONRY_QAUTO_SEG )
 				copy_files("${OpenCV_WORLD_DEBUG_DLL}" ${CLOUDCOMPARE_DEST_FOLDER} 2)
 			endif()
 		endif()
-	  
+
 	endif()
-	
+
 endif()

--- a/qManualSeg/CMakeLists.txt
+++ b/qManualSeg/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 3.0 )
+cmake_minimum_required( VERSION 3.5 )
 
 # CloudCompare Masonry Manual Segmentation plugin
 option( PLUGIN_STANDARD_MASONRY_QMANUAL_SEG "Check to install qManualSeg plugin" OFF )
@@ -6,7 +6,7 @@ option( PLUGIN_STANDARD_MASONRY_QMANUAL_SEG "Check to install qManualSeg plugin"
 if ( PLUGIN_STANDARD_MASONRY_QMANUAL_SEG )
 
     project( QMANUAL_SEG_PLUGIN )
-    
+
     AddPlugin( NAME ${PROJECT_NAME} )
 
 
@@ -20,7 +20,7 @@ if ( PLUGIN_STANDARD_MASONRY_QMANUAL_SEG )
 		PRIVATE
 			${CMAKE_CURRENT_SOURCE_DIR}
 	)
- 
+
 	# Find Packages
 	# Find PCL
 	#set( PCL_DIR "C:/Program Files/PCL 1.9.1") #DGM: can't do that as it will obviously conflict with most of the users settings ;)
@@ -46,7 +46,7 @@ if ( PLUGIN_STANDARD_MASONRY_QMANUAL_SEG )
 		# [C/C++]>[Preprocessor]>[Preprocessor Definitions]
 		add_definitions( ${PCL_DEFINITIONS} )
 
-		# For Use Not PreCompiled Features 
+		# For Use Not PreCompiled Features
 		#add_definitions( -DPCL_NO_PRECOMPILE )
 
 		# [Linker]>[General]>[Additional Library Directories]


### PR DESCRIPTION
- Set cmake minimal version to 3.5. This change should be harmless and avoid nasty deprecation warnings on recent version of cmake.

- Improve a bit formatting too.